### PR TITLE
Support CommonJS modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ yarn add nobuhsi-config
 Create an application (`app.js`):
 
 ```js
-const nc = require('nobushi-config').default;
+const nc = require('nobushi-config');
 
 const config = nc(process.env).defaults({
   port: 3000,

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,59 +1,13 @@
-import nc from './index';
+import nc from './nc';
 
-describe('nc(process.env).defaults(defaults)', () => {
-  const env = {
-    PORT: '8080',
-    AUTH_JWT_SECRET: 'Test Secret',
-    FACEBOOK_SECRET: '7fd670edc01845e9aca2f3d70d11339d',
-  };
-  const defaults = {
-    port: 3000,
-    databaseUrl: 'sqlite:database.sqlite',
-    api: {
-      serverUrl: 'http://localhost:${port}',
-      timeout: 120000,
-    },
-    auth: {
-      jwt: { secret: 'Default Secret' },
-      facebook: {
-        id: '${FACEBOOK_ID:965881723876770}',
-        secret: '${FACEBOOK_SECRET:c0e8f5ba8f8e41688eb385a24a8a40b0}',
-      },
-    },
-  };
+const index = require('./index');
 
-  it('should overwrite defaults.port by process.env.PORT', () => {
-    const config = nc(env).defaults(defaults);
-    expect(config.port).toBe(env.PORT);
+describe('index', () => {
+  it('export nc as CommonJS module', () => {
+    expect(index).toBe(nc);
   });
 
-  it('should not overwrite defaults.databaseUrl', () => {
-    const config = nc(env).defaults(defaults);
-    expect(config.databaseUrl).toBe(defaults.databaseUrl);
-  });
-
-  it('should resolve placeholder with a value', () => {
-    const config = nc(env).defaults(defaults);
-    expect(config.api.serverUrl).toBe(`http://localhost:${env.PORT}`);
-  });
-
-  it('should resolve placeholder with a environment variables', () => {
-    const config = nc(env).defaults(defaults);
-    expect(config.auth.facebook.secret).toBe(env.FACEBOOK_SECRET);
-  });
-
-  it('should resolve placeholder with a default value', () => {
-    const config = nc(env).defaults(defaults);
-    expect(config.auth.facebook.id).toBe('965881723876770');
-  });
-
-  it('should overwrite default.auth.jwt.secret by process.env.AUTH_JWT_SECRET', () => {
-    const config = nc(env).defaults(defaults);
-    expect(config.auth.jwt.secret).toBe(env.AUTH_JWT_SECRET);
-  });
-
-  it('should keep data type', () => {
-    const config = nc(env).defaults(defaults);
-    expect(config.api.timeout).toBe(defaults.api.timeout);
+  it('export nc as ES module', () => {
+    expect(index.default).toBe(nc);
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,22 +1,3 @@
-import Config, { Middleware } from './Config';
-import ConfigSource from './ConfigSource';
-import entries from './entries';
-import placeholder from './middlewares/placeholder';
+import nc from './nc';
 
-export default function config(...args: any[]) {
-  const middlewares: Middleware[] = [
-    placeholder(),
-  ];
-
-  return {
-    use(middleware: Middleware): void {
-      middlewares.push(middleware);
-    },
-
-    defaults<T>(obj: T): T {
-      const sources = [...args, obj].map(x => new ConfigSource(entries(x)));
-      const config = new Config(sources, middlewares);
-      return config.extend(obj);
-    },
-  };
-}
+export = Object.assign(nc, { default: nc });

--- a/src/nc.test.ts
+++ b/src/nc.test.ts
@@ -1,0 +1,59 @@
+import nc from './nc';
+
+describe('nc(process.env).defaults(defaults)', () => {
+  const env = {
+    PORT: '8080',
+    AUTH_JWT_SECRET: 'Test Secret',
+    FACEBOOK_SECRET: '7fd670edc01845e9aca2f3d70d11339d',
+  };
+  const defaults = {
+    port: 3000,
+    databaseUrl: 'sqlite:database.sqlite',
+    api: {
+      serverUrl: 'http://localhost:${port}',
+      timeout: 120000,
+    },
+    auth: {
+      jwt: { secret: 'Default Secret' },
+      facebook: {
+        id: '${FACEBOOK_ID:965881723876770}',
+        secret: '${FACEBOOK_SECRET:c0e8f5ba8f8e41688eb385a24a8a40b0}',
+      },
+    },
+  };
+
+  it('should overwrite defaults.port by process.env.PORT', () => {
+    const config = nc(env).defaults(defaults);
+    expect(config.port).toBe(env.PORT);
+  });
+
+  it('should not overwrite defaults.databaseUrl', () => {
+    const config = nc(env).defaults(defaults);
+    expect(config.databaseUrl).toBe(defaults.databaseUrl);
+  });
+
+  it('should resolve placeholder with a value', () => {
+    const config = nc(env).defaults(defaults);
+    expect(config.api.serverUrl).toBe(`http://localhost:${env.PORT}`);
+  });
+
+  it('should resolve placeholder with a environment variables', () => {
+    const config = nc(env).defaults(defaults);
+    expect(config.auth.facebook.secret).toBe(env.FACEBOOK_SECRET);
+  });
+
+  it('should resolve placeholder with a default value', () => {
+    const config = nc(env).defaults(defaults);
+    expect(config.auth.facebook.id).toBe('965881723876770');
+  });
+
+  it('should overwrite default.auth.jwt.secret by process.env.AUTH_JWT_SECRET', () => {
+    const config = nc(env).defaults(defaults);
+    expect(config.auth.jwt.secret).toBe(env.AUTH_JWT_SECRET);
+  });
+
+  it('should keep data type', () => {
+    const config = nc(env).defaults(defaults);
+    expect(config.api.timeout).toBe(defaults.api.timeout);
+  });
+});

--- a/src/nc.ts
+++ b/src/nc.ts
@@ -1,0 +1,23 @@
+import Config, { Middleware } from './Config';
+import ConfigSource from './ConfigSource';
+import entries from './entries';
+import placeholder from './middlewares/placeholder';
+
+export default function nc(...args: any[]) {
+  const middlewares: Middleware[] = [
+    placeholder(),
+  ];
+
+  return {
+    use(...middleware: Middleware[]) {
+      middlewares.push(...middleware);
+      return this;
+    },
+
+    defaults<T>(obj: T): T {
+      const sources = [...args, obj].map(x => new ConfigSource(entries(x)));
+      const config = new Config(sources, middlewares);
+      return config.extend(obj);
+    },
+  };
+}


### PR DESCRIPTION
In addition to ES Modules, add support for CommonJS modules.

CommonJS modules style:
```js
const nc = require('nobushi-config');
```

ES modules style:
```js
import nc from 'nobushi-config';
```